### PR TITLE
docs: typo in atom-with-storage.mdx

### DIFF
--- a/docs/utils/atom-with-storage.mdx
+++ b/docs/utils/atom-with-storage.mdx
@@ -32,7 +32,7 @@ The `atomWithStorage` function creates an atom with a value persisted in `localS
 
 **storage** (optional): an object with:
 
-- `getItem` and `setItem` methods for storing/retreiving persisted state; defaults to using `localStorage` for storage/retreival and `JSON.stringify()`/`JSON.parse()` for serialization/deserialization.
+- `getItem` and `setItem` methods for storing/retrieving persisted state; defaults to using `localStorage` for storage/retrieval and `JSON.stringify()`/`JSON.parse()` for serialization/deserialization.
 - Optionally, the storage has a `subscribe` property, which can be used to synchronize storage. The default `localStorage` handles `storage` events for cross-tab synchronization.
 - Optionally, the storage has a `delayInit` (`boolean`) property, which can be used to tell jotai whether to use Suspense
   - `delayInit: true` will not suspend when first reading the value of your atom


### PR DESCRIPTION
1) Fixed typo "retreiving" to "retrieving".
2) Fixed typo "retreival" to "retrieval".