### PR TITLE
docs: typo in query.mdx

### DIFF
--- a/docs/integrations/query.mdx
+++ b/docs/integrations/query.mdx
@@ -94,7 +94,7 @@ const UserData = () => {
 
 ### SSR support
 
-Both atoms can be used within the context of a server side rendered app, such as a next.js app or gastby app. You can [use both options](https://react-query.tanstack.com/guides/ssr) that React Query supports for use within SSR apps, [hydration](https://react-query.tanstack.com/guides/ssr#using-hydration) or [`initialData`](https://react-query.tanstack.com/guides/ssr#using-initialdata).
+Both atoms can be used within the context of a server side rendered app, such as a next.js app or Gatsby app. You can [use both options](https://react-query.tanstack.com/guides/ssr) that React Query supports for use within SSR apps, [hydration](https://react-query.tanstack.com/guides/ssr#using-hydration) or [`initialData`](https://react-query.tanstack.com/guides/ssr#using-initialdata).
 
 ### Examples
 


### PR DESCRIPTION
Fixed typo "gastby" to "Gatsby".